### PR TITLE
Add support for Preact

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -218,16 +218,15 @@
   "preact": {
     "var": "preact",
     "versions": {
-      ">= 1.2.0": {
+      ">= 2.4.0": {
         "development": "https://unpkg.com/preact@[version]/dist/preact.js",
         "production": "https://unpkg.com/preact@[version]/dist/preact.min.js"
       }
     }
   },
   "preact-compat": {
-    "var": "PreactCompat",
     "versions": {
-      ">= 0.1.0": {
+      ">= 1.0.0": {
         "development": "https://unpkg.com/preact-compat@[version]/dist/preact-compat.js",
         "production": "https://unpkg.com/preact-compat@[version]/dist/preact-compat.min.js"
       }

--- a/modules.json
+++ b/modules.json
@@ -225,6 +225,7 @@
     }
   },
   "preact-compat": {
+    "var": "preactCompat",
     "versions": {
       ">= 1.0.0": {
         "development": "https://unpkg.com/preact-compat@[version]/dist/preact-compat.js",

--- a/modules.json
+++ b/modules.json
@@ -214,5 +214,23 @@
         "production": "https://unpkg.com/zone.js@[version]/dist/zone.min.js"
       }
     }
+  },
+  "preact": {
+    "var": "preact",
+    "versions": {
+      ">= 1.2.0": {
+        "development": "https://unpkg.com/preact@[version]/dist/preact.js",
+        "production": "https://unpkg.com/preact@[version]/dist/preact.min.js"
+      }
+    }
+  },
+  "preact-compat": {
+    "var": "PreactCompat",
+    "versions": {
+      ">= 0.1.0": {
+        "development": "https://unpkg.com/preact-compat@[version]/dist/preact-compat.js",
+        "production": "https://unpkg.com/preact-compat@[version]/dist/preact-compat.min.js"
+      }
+    }
   }
 }


### PR DESCRIPTION
* Added `unpkg` links for `preact` and `preact-compat`
* Also closes https://github.com/mastilver/dynamic-cdn-webpack-plugin/issues/28