### PR TITLE
support rxjs 6 and only support version 5 and above

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -326,10 +326,14 @@
   "rxjs": {
     "var": "Rx",
     "versions": {
-      "*": {
+      ">= 5.0.0 <= 6.0.0-alpha.3": {
         "development": "https://unpkg.com/rxjs@[version]/bundles/Rx.js",
         "production": "https://unpkg.com/rxjs@[version]/bundles/Rx.min.js"
-      }
+      },
+      ">= 6.0.0-alpha.4": {
+        "development": "https://unpkg.com/rxjs@[version]/bundles/rxjs.umd.js",
+        "production": "https://unpkg.com/rxjs@[version]/bundles/rxjs.umd.min.js"
+      }      
     }
   },
   "zone.js": {


### PR DESCRIPTION
RXJS 6 bundle names seem to have been renamed to rxjs.umd prefix.