### PR TITLE
added a-frame to the list of modules

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -394,5 +394,14 @@
         "production": "https://unpkg.com/jquery@[version]/dist/jquery.min.js"
       }
     }
-  }
+  },
+  "aframe": {
+    "var": "aframe",
+    "versions": {
+      ">= 0.1.0": {
+        "development": "https://aframe.io/releases/[version]/aframe.js",
+        "production": "https://aframe.io/releases/[version]/aframe.min.js"
+      }
+    }
+  },
 }

--- a/modules.json
+++ b/modules.json
@@ -398,9 +398,9 @@
   "aframe": {
     "var": "aframe",
     "versions": {
-      ">= 0.1.0": {
-        "development": "https://aframe.io/releases/[version]/aframe.js",
-        "production": "https://aframe.io/releases/[version]/aframe.min.js"
+      ">= 0.9.0": {
+        "development": "https://unpkg.com/aframe@[version]/dist/aframe-master.js",
+        "production": "https://unpkg.com/aframe@[version]/dist/aframe-master.min.js"
       }
     }
   },


### PR DESCRIPTION
I used aframe instead of a-frame to follow the convention set by the npm module rather than the branding / documentation.