### PR TITLE
fix: update the rules for react-router and react-router-dom >= 6.0.0

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -80,18 +80,34 @@
   "react-router": {
     "var": "ReactRouter",
     "versions": {
-      ">= 4.0.0": {
+      ">= 4.0.0 < 6.0.0": {
         "development": "https://unpkg.com/react-router@[version]/umd/react-router.js",
         "production": "https://unpkg.com/react-router@[version]/umd/react-router.min.js"
+      },
+      ">= 6.0.0 <= 6.4.0-pre.2": {
+        "development": "https://unpkg.com/react-router@[version]/umd/react-router.development.js",
+        "production": "https://unpkg.com/react-router@[version]/umd/react-router.production.min.js"
+      },
+      ">= 6.4.0-pre.4": {
+        "development": "https://unpkg.com/react-router@[version]/dist/umd/react-router.development.js",
+        "production": "https://unpkg.com/react-router@[version]/dist/umd/react-router.production.min.js"
       }
     }
   },
   "react-router-dom": {
     "var": "ReactRouterDOM",
     "versions": {
-      ">= 4.0.0": {
+      ">= 4.0.0 < 6.0.0": {
         "development": "https://unpkg.com/react-router-dom@[version]/umd/react-router-dom.js",
         "production": "https://unpkg.com/react-router-dom@[version]/umd/react-router-dom.min.js"
+      },
+      ">= 6.0.0 <= 6.4.0-pre.3": {
+        "development": "https://unpkg.com/react-router-dom@[version]/umd/react-router-dom.development.js",
+        "production": "https://unpkg.com/react-router-dom@[version]/umd/react-router-dom.production.min.js"
+      },
+      ">= 6.4.0-pre.4": {
+        "development": "https://unpkg.com/react-router-dom@[version]/dist/umd/react-router-dom.development.js",
+        "production": "https://unpkg.com/react-router-dom@[version]/dist/umd/react-router-dom.production.min.js"
       }
     }
   },


### PR DESCRIPTION
Hi all,

In this PR, I update the rules for react-router and react-router-dom >= 6.0.0.

Based on the rules defined in modules.json, CDN replied the files not found for react-router and react-router-dom.
I try to fetch the files on CDN for all versions programmatically. The shorten result is shown below.
> fetch => done https://unpkg.com/react-router@5.3.3/umd/react-router.min.js
> fetch => done https://unpkg.com/react-router@5.3.4/umd/react-router.min.js
> fetch => error https://unpkg.com/react-router@6.0.0-alpha.0/umd/react-router.min.js
> fetch => error https://unpkg.com/react-router@6.0.0-alpha.1/umd/react-router.min.js
> ...
> fetch => error https://unpkg.com/react-router@6.4.2/umd/react-router.min.js
> fetch => error https://unpkg.com/react-router@6.4.3-pre.0/umd/react-router.min.js
> fetch => error https://unpkg.com/react-router@6.4.3-pre.1/umd/react-router.min.js

The breaking change for react-router and react-router-dom both are  above the 6.0.0.
Therefore, I visit the CDN website and update the rules manually.
